### PR TITLE
Add syntax highlighting for code blocks in posts

### DIFF
--- a/posts/test.md
+++ b/posts/test.md
@@ -16,3 +16,21 @@ updated: 2023-11-17
 If `src` attribute is set, all relative links within 
 that markdown document should be transformed
 to be **relative** to `src` instead of `location.href`.
+
+```js
+// this is a code block for javascript
+const convertMarkdownFilesToHtml = async () => {
+    let numPostsConverted = 0;
+
+    const posts = [];
+    const inputFiles = fs.readdirSync(postsInputDir);
+    for (const inputFile of inputFiles) {
+        // only process markdown files
+        if (path.extname(inputFile) !== ".md") {
+            continue;
+        }
+        // ...
+    }
+};
+await convertMarkdownFilesToHtml();
+```

--- a/public/posts/post-template.html
+++ b/public/posts/post-template.html
@@ -8,6 +8,16 @@
 
     <link rel="stylesheet" href="../css/main.css" />
 
+    <!-- setup syntax highlighting of code blocks via highlight.js -->
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark-dimmed.min.css"
+    />
+    <script type="module">
+      import hljs from "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/es/highlight.min.js";
+      hljs.highlightAll();
+    </script>
+
     <script>
       // set initial theme based on localStorage
       const themeAttrib = "data-theme";


### PR DESCRIPTION
Closes #6 

- Added [highlight.js](https://github.com/highlightjs/highlight.js) library js and style in `post-template.html`
- Added example code block in `/posts/test.md` and verified that it looks pretty when converted in `public/posts/test.html`